### PR TITLE
Deployment testing

### DIFF
--- a/game/game_communication.go
+++ b/game/game_communication.go
@@ -11,12 +11,13 @@ func (gameState GameState) send(player_index int, msg Message, wait_groups ...*s
 	}
 
 	// fmt.Println("Called send")
-	fmt.Println("logging out message", msg)
+	fmt.Println("logging out message", msg, player_index)
 	go func(gs GameState, message Message) {
 		if len(wait_groups) == 1 {
 			defer wait_groups[0].Done()
 		}
-		fmt.Println("inside go", message) // lots of output here
+		encodedMessage := createEncodedMessage(message)
+		fmt.Println("inside go", string(encodedMessage), player_index) // lots of output here
 		gs.PlayerChannels[player_index] <- createEncodedMessage(message)
 	}(gameState, msg)
 }

--- a/game/game_communication.go
+++ b/game/game_communication.go
@@ -11,11 +11,12 @@ func (gameState GameState) send(player_index int, msg Message, wait_groups ...*s
 	}
 
 	// fmt.Println("Called send")
+	fmt.Println("logging out message", msg)
 	go func(msg Message) {
 		if len(wait_groups) == 1 {
 			defer wait_groups[0].Done()
 		}
-		fmt.Println(msg) // lots of output here
+		fmt.Println("inside go", msg) // lots of output here
 		gameState.PlayerChannels[player_index] <- createEncodedMessage(msg)
 	}(msg)
 }

--- a/game/game_communication.go
+++ b/game/game_communication.go
@@ -11,13 +11,13 @@ func (gameState GameState) send(player_index int, msg Message, wait_groups ...*s
 	}
 
 	// fmt.Println("Called send")
-	go func() {
+	go func(msg Message) {
 		if len(wait_groups) == 1 {
 			defer wait_groups[0].Done()
 		}
 		fmt.Println(msg) // lots of output here
 		gameState.PlayerChannels[player_index] <- createEncodedMessage(msg)
-	}()
+	}(msg)
 }
 
 func (gameState GameState) distributeHands() {

--- a/game/game_communication.go
+++ b/game/game_communication.go
@@ -12,13 +12,13 @@ func (gameState GameState) send(player_index int, msg Message, wait_groups ...*s
 
 	// fmt.Println("Called send")
 	fmt.Println("logging out message", msg)
-	go func(msg Message) {
+	go func(gs GameState, message Message) {
 		if len(wait_groups) == 1 {
 			defer wait_groups[0].Done()
 		}
-		fmt.Println("inside go", msg) // lots of output here
-		gameState.PlayerChannels[player_index] <- createEncodedMessage(msg)
-	}(msg)
+		fmt.Println("inside go", message) // lots of output here
+		gs.PlayerChannels[player_index] <- createEncodedMessage(message)
+	}(gameState, msg)
 }
 
 func (gameState GameState) distributeHands() {

--- a/game/game_communication.go
+++ b/game/game_communication.go
@@ -11,14 +11,14 @@ func (gameState GameState) send(player_index int, msg Message, wait_groups ...*s
 	}
 
 	// fmt.Println("Called send")
-	fmt.Println("logging out message", msg, player_index)
+	// fmt.Println("logging out message", msg, player_index)
 	encodedMessage := createEncodedMessage(msg)
 	go func(gs GameState, encodedMsg []byte) { // VERY IMPORTANT. Must not modify gs in any way
 		if len(wait_groups) == 1 {
 			defer wait_groups[0].Done()
 		}
 
-		fmt.Println("inside go", string(encodedMessage), player_index) // lots of output here
+		// fmt.Println("inside go", string(encodedMessage), player_index) // lots of output here
 		gs.PlayerChannels[player_index] <- encodedMsg
 		// gs.PlayerChannels[player_index] <- createEncodedMessage(msg Message)
 	}(gameState, encodedMessage)
@@ -42,9 +42,9 @@ func (gameState GameState) distributeHands() {
 
 func (gameState GameState) revealHands() {
 	playerHandContentsMessage := Message{TypeDescriptor: "PlayerHandsContents", Contents: PlayerHandsContents{gameState.PlayerHands}}
-	fmt.Println(playerHandContentsMessage)
+	// fmt.Println(playerHandContentsMessage)
 	gameState.broadcast(playerHandContentsMessage)
-	fmt.Println(playerHandContentsMessage)
+	// fmt.Println(playerHandContentsMessage)
 }
 
 func (gameState GameState) broadcast(message Message, optional_use_wait_group ...bool) {

--- a/game/game_communication.go
+++ b/game/game_communication.go
@@ -11,13 +11,13 @@ func (gameState GameState) send(player_index int, msg Message, wait_groups ...*s
 	}
 
 	// fmt.Println("Called send")
-	go func(gameState GameState, msg Message) {
+	go func() {
 		if len(wait_groups) == 1 {
 			defer wait_groups[0].Done()
 		}
 
 		gameState.PlayerChannels[player_index] <- createEncodedMessage(msg)
-	}(gameState, msg)
+	}()
 }
 
 func (gameState GameState) distributeHands() {
@@ -40,6 +40,7 @@ func (gameState GameState) revealHands() {
 	playerHandContentsMessage := Message{TypeDescriptor: "PlayerHandsContents", Contents: PlayerHandsContents{gameState.PlayerHands}}
 	fmt.Println(playerHandContentsMessage)
 	gameState.broadcast(playerHandContentsMessage)
+	fmt.Println(playerHandContentsMessage)
 }
 
 func (gameState GameState) broadcast(message Message, optional_use_wait_group ...bool) {

--- a/game/game_communication.go
+++ b/game/game_communication.go
@@ -11,13 +11,13 @@ func (gameState GameState) send(player_index int, msg Message, wait_groups ...*s
 	}
 
 	// fmt.Println("Called send")
-	go func() {
+	go func(gameState GameState, msg Message) {
 		if len(wait_groups) == 1 {
 			defer wait_groups[0].Done()
 		}
 
 		gameState.PlayerChannels[player_index] <- createEncodedMessage(msg)
-	}()
+	}(gameState, msg)
 }
 
 func (gameState GameState) distributeHands() {

--- a/game/game_communication.go
+++ b/game/game_communication.go
@@ -15,7 +15,7 @@ func (gameState GameState) send(player_index int, msg Message, wait_groups ...*s
 		if len(wait_groups) == 1 {
 			defer wait_groups[0].Done()
 		}
-
+		fmt.Println(msg) // lots of output here
 		gameState.PlayerChannels[player_index] <- createEncodedMessage(msg)
 	}()
 }

--- a/game/game_communication.go
+++ b/game/game_communication.go
@@ -12,14 +12,16 @@ func (gameState GameState) send(player_index int, msg Message, wait_groups ...*s
 
 	// fmt.Println("Called send")
 	fmt.Println("logging out message", msg, player_index)
-	go func(gs GameState, message Message) {
+	encodedMessage := createEncodedMessage(msg)
+	go func(gs GameState, encodedMsg []byte) { // VERY IMPORTANT. Must not modify gs in any way
 		if len(wait_groups) == 1 {
 			defer wait_groups[0].Done()
 		}
-		encodedMessage := createEncodedMessage(message)
+
 		fmt.Println("inside go", string(encodedMessage), player_index) // lots of output here
-		gs.PlayerChannels[player_index] <- createEncodedMessage(message)
-	}(gameState, msg)
+		gs.PlayerChannels[player_index] <- encodedMsg
+		// gs.PlayerChannels[player_index] <- createEncodedMessage(msg Message)
+	}(gameState, encodedMessage)
 }
 
 func (gameState GameState) distributeHands() {

--- a/game/game_communication.go
+++ b/game/game_communication.go
@@ -38,6 +38,7 @@ func (gameState GameState) distributeHands() {
 
 func (gameState GameState) revealHands() {
 	playerHandContentsMessage := Message{TypeDescriptor: "PlayerHandsContents", Contents: PlayerHandsContents{gameState.PlayerHands}}
+	fmt.Println(playerHandContentsMessage)
 	gameState.broadcast(playerHandContentsMessage)
 }
 

--- a/main.go
+++ b/main.go
@@ -86,6 +86,7 @@ func manageWsConn(ws *websocket.Conn, thisChan chan []byte, allChans *map[chan [
 	for {
 		select {
 		case b := <-thisChan:
+			fmt.Println("This channel just got", string(b))
 			_, err := ws.Write(b)
 			if err != nil {
 				fmt.Println(err.Error())

--- a/main.go
+++ b/main.go
@@ -146,7 +146,7 @@ func main() {
 
 	fmt.Println("Server running")
 
-	err := http.ListenAndServe("localhost:12345", nil)
+	err := http.ListenAndServe(":32156", nil)
 	if err != nil {
 		panic("ListenAndServe: " + err.Error())
 	}

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func manageWsConn(ws *websocket.Conn, thisChan chan []byte, allChans *map[chan [
 	for {
 		select {
 		case b := <-thisChan:
-			fmt.Println("This channel just got", string(b))
+			// fmt.Println("This channel just got", string(b))
 			_, err := ws.Write(b)
 			if err != nil {
 				fmt.Println(err.Error())


### PR DESCRIPTION
Changed so that we are deployable. Also identifed a race condition stemming from revealHands revealing a slice of PlayerHands which is a pointer to memory and so in essence, acts as a dynamic reference. Fixed by making encoded message outside of the go routine.

Added previously failing test.