### PR TITLE
Handle early disconnects

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,11 +14,11 @@ import (
 )
 
 func tidyConnection(thisChan chan []byte, thisClientID string, channelLocations *message_handler_interface.ChannelLocations, globalClientIDsToChannel *map[string]chan []byte) {
-	channelHandler := (*channelLocations)[thisChan]
+	channelHandler, ok := (*channelLocations)[thisChan]
 	if channelHandler != nil {
 		channelHandler.RemoveChannel(thisChan)
 	} else {
-		fmt.Println("Channel Handler was nil")
+		fmt.Printf("Channel Handler was nil and ok was %t \n", ok)
 	}
 	// (*channelLocations)[thisChan].MoveChannel(thisChan, nil)
 	delete(*channelLocations, thisChan)

--- a/message_handlers/game/game.go
+++ b/message_handlers/game/game.go
@@ -19,6 +19,7 @@ type GameState struct {
 	PalacifoablePlayers []bool
 	IsPalacifoRound     bool
 	// GlobalUnassignedPlayerHandler message_handlers.MessageHandler
+	// InactivePlayers []bool
 }
 
 type GamesMap map[string]*GameState
@@ -120,6 +121,8 @@ func (gameState *GameState) StartNewGame() {
 
 func (gameState *GameState) startNewRound() {
 	fmt.Println("Called StartNewRound")
+	// need to purge inactivePlayers
+	gameState.CleanUpInactivePlayers()
 	gameState.randomiseCurrentHands()
 	gameState.distributeHands()
 	// Zero out previous

--- a/message_handlers/game/game.go
+++ b/message_handlers/game/game.go
@@ -188,7 +188,7 @@ func (gameState *GameState) updatePlayerIndex(moveType MoveType, optional_player
 		gameState.CurrentPlayerIndex += 1
 		gameState.CurrentPlayerIndex %= len(gameState.PlayerHands)
 	}
-	err := gameState.findNextAlivePlayerInclusive()
+	err := gameState.FindNextAlivePlayerInclusive()
 	return err
 }
 

--- a/message_handlers/game/game_communication.go
+++ b/message_handlers/game/game_communication.go
@@ -10,6 +10,9 @@ func (gameState GameState) send(player_index int, msg messages.Message, wait_gro
 	if len(wait_groups) == 1 {
 		wait_groups[0].Add(1)
 	}
+	if gameState.PlayerChannels[player_index] == nil {
+		return
+	}
 
 	// fmt.Println("Called send")
 	// fmt.Println("logging out message", msg, player_index)

--- a/message_handlers/game/game_communication.go
+++ b/message_handlers/game/game_communication.go
@@ -45,7 +45,8 @@ func (gameState GameState) distributeHands() {
 }
 
 func (gameState GameState) revealHands() {
-	playerHandsContents := PlayerHandsContents{PlayerHands: gameState.PlayerHands, FinalBet: gameState.PrevMove}
+	prevMove := gameState.PrevMove()
+	playerHandsContents := PlayerHandsContents{PlayerHands: gameState.PlayerHands, FinalBet: prevMove}
 	// could also set the moveType of the FinalBet to be dudo or calza
 	playerHandContentsMessage := messages.Message{TypeDescriptor: "PlayerHandsContents", Contents: playerHandsContents}
 	// fmt.Println(playerHandContentsMessage)

--- a/message_handlers/game/game_logic.go
+++ b/message_handlers/game/game_logic.go
@@ -67,7 +67,7 @@ func (gameState GameState) alivePlayerIndices() []int {
 	// 	util.Map(func(p PlayerHand) int { return len(p) }, gameState.PlayerHands))
 	alivePlayerIndices := make([]int, 0, len(gameState.PlayerHands))
 	for i, playerHand := range gameState.PlayerHands {
-		if len(playerHand) > 0 {
+		if (gameState.PlayerChannels[i] != nil) && len(playerHand) > 0 {
 			alivePlayerIndices = append(alivePlayerIndices, i)
 		}
 	}

--- a/message_handlers/game/game_logic.go
+++ b/message_handlers/game/game_logic.go
@@ -14,13 +14,13 @@ func (gameState GameState) PlayersAllDead() bool {
 			hand_sums = false
 		}
 	}
-	return hand_sums
+	return hand_sums // should be len(gameState.alivePlayerIndices)>0
 }
 
 func (gameState GameState) isBetTrue() bool {
 	fmt.Println("Called isBetTrue")
 	// TODO, for Dudo
-	bet := gameState.PrevMove.Value
+	bet := gameState.PrevMove().Value
 	var dice_face_counts []int
 	if !gameState.IsPalacifoRound {
 		dice_face_counts = count_dice_faces_considering_wild_ones(gameState)
@@ -34,7 +34,7 @@ func (gameState GameState) isBetTrue() bool {
 func (gameState GameState) isBetExactlyTrue() bool {
 	fmt.Println("Called isBetExactlyTrue")
 	// TODO, for Calza
-	bet := gameState.PrevMove.Value
+	bet := gameState.PrevMove().Value
 	dice_face_counts := count_dice_faces_considering_wild_ones(gameState)
 
 	return dice_face_counts[bet.FaceVal] == bet.NumDice
@@ -95,4 +95,12 @@ func (gameState GameState) PreviousAlivePlayer() (int, error) {
 func (gameState GameState) checkPlayerWin(candidate_victor int) bool {
 	alivePlayers := gameState.alivePlayerIndices()
 	return len(alivePlayers) == 1 && alivePlayers[0] == candidate_victor
+}
+
+func (gameState GameState) PrevMove() PlayerMove {
+	if len(gameState.RoundMoveHistory) == 0 {
+		return PlayerMove{}
+	}
+	return gameState.RoundMoveHistory[len(gameState.RoundMoveHistory)-1]
+
 }

--- a/message_handlers/game/game_logic_test.go
+++ b/message_handlers/game/game_logic_test.go
@@ -8,6 +8,8 @@ import (
 
 func Test_alivePlayerIndices(t *testing.T) { // ✓
 	var gameState GameState
+	gameState.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
+
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{1, 2, 3}), PlayerHand([]int{5, 4, 1}), PlayerHand([]int{4, 5, 6})}
 	alivePlayerIndices := gameState.alivePlayerIndices()
 	t.Log(alivePlayerIndices)
@@ -18,6 +20,7 @@ func Test_alivePlayerIndices(t *testing.T) { // ✓
 
 func Test_previousAlivePlayer(t *testing.T) { // ✓
 	var gameState GameState
+	gameState.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{1, 2, 3}), PlayerHand([]int{5, 4, 1}), PlayerHand([]int{4, 5, 6})}
 	gameState.CurrentPlayerIndex = 1
 	previousAlivePlayer, err := gameState.PreviousAlivePlayer()
@@ -31,6 +34,7 @@ func Test_previousAlivePlayer(t *testing.T) { // ✓
 
 func Test_previousAlivePlayerCurrentPlayer0(t *testing.T) { // ✓
 	var gameState GameState
+	gameState.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{1, 2, 3}), PlayerHand([]int{5, 4, 1}), PlayerHand([]int{4, 5, 6})}
 	gameState.CurrentPlayerIndex = 0
 	previousAlivePlayer, err := gameState.PreviousAlivePlayer()
@@ -44,6 +48,7 @@ func Test_previousAlivePlayerCurrentPlayer0(t *testing.T) { // ✓
 
 func Test_previousAlivePlayerOneDead(t *testing.T) { // fine, similar to above (doesn't have to skip over dead player)
 	var gameState GameState
+	gameState.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{1, 2, 3}), PlayerHand([]int{}), PlayerHand([]int{4, 5, 6})}
 	gameState.CurrentPlayerIndex = 0
 	previousAlivePlayer, err := gameState.PreviousAlivePlayer()
@@ -56,6 +61,7 @@ func Test_previousAlivePlayerOneDead(t *testing.T) { // fine, similar to above (
 
 func Test_previousAlivePlayerAllDead(t *testing.T) { // ✓
 	var gameState GameState
+	gameState.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{}), PlayerHand([]int{}), PlayerHand([]int{})}
 	gameState.CurrentPlayerIndex = 0
 	_, err := gameState.PreviousAlivePlayer()
@@ -68,6 +74,7 @@ func Test_previousAlivePlayerAllDead(t *testing.T) { // ✓
 
 func Test_previousAlivePlayerOnePlayerAlive(t *testing.T) { // isn't this supposed to be a win? No, that is computed in updatePlayerIndex ✓
 	var gameState GameState
+	gameState.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{5, 6, 2}), PlayerHand([]int{}), PlayerHand([]int{})}
 	gameState.CurrentPlayerIndex = 0
 	_, err := gameState.PreviousAlivePlayer()
@@ -82,6 +89,7 @@ func Test_previousAlivePlayerOnePlayerAlive(t *testing.T) { // isn't this suppos
 
 func Test_previousAlivePlayerOneSkipInternal(t *testing.T) {
 	var gameState GameState
+	gameState.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{1, 2, 3}), PlayerHand([]int{}), PlayerHand([]int{4, 5, 6})}
 	gameState.CurrentPlayerIndex = 2
 	previousAlivePlayer, err := gameState.PreviousAlivePlayer()
@@ -94,6 +102,7 @@ func Test_previousAlivePlayerOneSkipInternal(t *testing.T) {
 
 func Test_previousAlivePlayerOneDeadSkipEnd(t *testing.T) {
 	var gameState GameState
+	gameState.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{1, 2, 3}), PlayerHand([]int{4, 5, 6}), PlayerHand([]int{})}
 	gameState.CurrentPlayerIndex = 0
 	previousAlivePlayer, err := gameState.PreviousAlivePlayer()

--- a/message_handlers/game/game_logic_test.go
+++ b/message_handlers/game/game_logic_test.go
@@ -112,3 +112,15 @@ func Test_previousAlivePlayerOneDeadSkipEnd(t *testing.T) {
 	util.Assert(t, previousAlivePlayer == 1)
 
 }
+
+func Test_alivePlayerIndicesInactivePlayers(t *testing.T) { // Jim
+	var gs GameState
+	gs.PlayerHands = []PlayerHand{{2}, {3}, {5}}
+	gs.InitialiseSlicesWithDefaults()
+	gs.PlayerChannels[1] = nil
+
+	api := gs.alivePlayerIndices()
+
+	util.Assert(t, slices.Equal(api, []int{0, 2}))
+	// t.FailNow()
+}

--- a/message_handlers/game/game_processplayermove.go
+++ b/message_handlers/game/game_processplayermove.go
@@ -6,13 +6,13 @@ import (
 )
 
 func (gameState GameState) checkNewBetValid(newBet Bet) bool {
-	betRejectedForOnesOnFirstTurn := gameState.PrevMove.MoveType != BET && newBet.FaceVal == 1
+	betRejectedForOnesOnFirstTurn := (gameState.PrevMove()).MoveType != BET && newBet.FaceVal == 1
 	if !gameState.IsPalacifoRound {
-		betIncreasing := newBet.isGreaterThan(gameState.PrevMove.Value)
+		betIncreasing := newBet.isGreaterThan(gameState.PrevMove().Value)
 		return betIncreasing && !betRejectedForOnesOnFirstTurn
 	}
-	betIncreasing := newBet.isGreaterThanPalacifo(gameState.PrevMove.Value)
-	if newBet.FaceVal != gameState.PrevMove.Value.FaceVal { // could be refactored maybe
+	betIncreasing := newBet.isGreaterThanPalacifo(gameState.PrevMove().Value)
+	if newBet.FaceVal != (gameState.PrevMove()).Value.FaceVal { // could be refactored maybe
 		currentPlayerCanChangeFaceVal := len(gameState.PlayerHands[gameState.CurrentPlayerIndex]) == 1
 		return betIncreasing && currentPlayerCanChangeFaceVal
 	}
@@ -45,7 +45,7 @@ func (gameState *GameState) processPlayerBet(playerMove PlayerMove) bool {
 
 	gameState.broadcastPlayerMove(playerMove)
 
-	gameState.PrevMove = playerMove
+	// gameState.PrevMove() = playerMove // Previously updated PrevMove
 
 	// Update current player
 	err := gameState.updatePlayerIndex(BET)
@@ -98,12 +98,12 @@ func (gameState *GameState) updatePlayerIndexFinalBet(dice_change_player_index, 
 func (gameState *GameState) processPlayerDudo() bool {
 	fmt.Println("in ProcessPlayerMove, made into case 'Dudo' ")
 
-	if gameState.PrevMove.MoveType != BET { // could condition on PrevMove.Value as well if we wanted
+	if gameState.PrevMove().MoveType != BET { // could condition on PrevMove().Value as well if we wanted
 		return false
 	}
 
 	// dudo should always be valid, as long as the current player // checked earlier
-	gameState.broadcastPlayerMove(PlayerMove{MoveType: DUDO})
+	gameState.broadcastPlayerMove(PlayerMove{MoveType: DUDO, PlayerIndex: gameState.CurrentPlayerIndex})
 	gameState.revealHands()
 	// calculate the result of the call:
 	// 1) who loses a dice (always happens)
@@ -139,7 +139,7 @@ func (gameState *GameState) processPlayerDudo() bool {
 func (gameState *GameState) processPlayerCalza() bool {
 	fmt.Println("Made into Case Calza")
 	//Input already valid
-	if gameState.PrevMove.MoveType != BET {
+	if gameState.PrevMove().MoveType != BET {
 		return false
 	}
 
@@ -152,7 +152,7 @@ func (gameState *GameState) processPlayerCalza() bool {
 		// We do not allow Calza with only 2 live players
 		return false
 	}
-	gameState.broadcastPlayerMove(PlayerMove{MoveType: CALZA})
+	gameState.broadcastPlayerMove(PlayerMove{MoveType: CALZA, PlayerIndex: gameState.CurrentPlayerIndex})
 	gameState.revealHands()
 	bet_true := gameState.isBetExactlyTrue()
 	// Not sure if the following code deserves a function
@@ -198,41 +198,4 @@ func (gameState *GameState) processPlayerCalza() bool {
 	gameState.startNewRound()
 	return true
 
-	// var dice_total_changing_player_index int
-	// var candidate_victor int
-	// previousAlivePlayer, err := gameState.PreviousAlivePlayer()
-	// if err != nil {
-	// 	fmt.Println(err.Error())
-	// 	return false
-	// }
-	// if bet_true {
-	// 	dice_total_changing_player_index = previousAlivePlayer
-	// 	candidate_victor = gameState.CurrentPlayerIndex
-	// } else {
-	// 	dice_total_changing_player_index = gameState.CurrentPlayerIndex
-	// 	candidate_victor = previousAlivePlayer
-	// }
-	// gameState.broadcast(messages.Message{"RoundResult", RoundResult{dice_total_changing_player_index, "dec"}})
-	// player_died, err := gameState.removeDice(dice_total_changing_player_index)
-	// if err != nil {
-	// 	fmt.Println(err.Error())
-	// 	return false
-	// }
-	// if player_died {
-	// 	gameState.broadcast(messages.Message{"RoundResult", RoundResult{dice_total_changing_player_index, "lose"}})
-	// 	gameState.send(dice_total_changing_player_index, messages.Message{"GameResult", GameResult{dice_total_changing_player_index, "lose"}})
-	// 	if gameState.checkPlayerWin(candidate_victor) {
-	// 		gameState.broadcast(messages.Message{"GameResult", GameResult{candidate_victor, "win"}})
-	// 		gameState.GameInProgress = false
-	// 		fmt.Println("A player has won and the game is no longer in progress")
-	// 		return true
-	// 	}
-	// }
-	// err = gameState.updatePlayerIndex(CALZA, dice_total_changing_player_index)
-	// if err != nil {
-	// 	fmt.Println(err)
-	// 	return false
-	// }
-	// gameState.startNewRound()
-	// return true
 }

--- a/message_handlers/game/game_processplayermove.go
+++ b/message_handlers/game/game_processplayermove.go
@@ -24,7 +24,7 @@ func (gameState GameState) broadcastPlayerMove(playerMove PlayerMove) {
 	gameState.Broadcast(messages.Message{TypeDescriptor: "RoundUpdate", Contents: RoundUpdate{MoveMade: playerMove, PlayerIndex: gameState.CurrentPlayerIndex}})
 }
 
-func (gameState GameState) broadcastNextPlayer() {
+func (gameState GameState) BroadcastNextPlayer() {
 	gameState.Broadcast(messages.Message{TypeDescriptor: "RoundResult", Contents: RoundResult{PlayerIndex: gameState.CurrentPlayerIndex, Result: "next"}})
 }
 
@@ -53,7 +53,7 @@ func (gameState *GameState) processPlayerBet(playerMove PlayerMove) bool {
 		fmt.Println(err.Error())
 		return false
 	}
-	gameState.broadcastNextPlayer()
+	gameState.BroadcastNextPlayer()
 	fmt.Println("Bet processed and broadcast RoundResult next")
 	return true
 }

--- a/message_handlers/game/game_processplayermove_test.go
+++ b/message_handlers/game/game_processplayermove_test.go
@@ -101,6 +101,7 @@ func Test_processPlayerDudoFalse(t *testing.T) {
 
 func Test_DudoIdentifyLosersWinnersDudoFalse(t *testing.T) {
 	var gs GameState
+	gs.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gs.PlayerHands = []PlayerHand{PlayerHand([]int{2, 2, 2}), PlayerHand([]int{1, 1}), PlayerHand([]int{4, 4})}
 	gs.PrevMove = PlayerMove{MoveType: BET, Value: Bet{5, 2}}
 	gs.CurrentPlayerIndex = 1
@@ -112,6 +113,7 @@ func Test_DudoIdentifyLosersWinnersDudoFalse(t *testing.T) {
 
 func Test_DudoIdentifyLosersWinnersDudoTrue(t *testing.T) {
 	var gs GameState
+	gs.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gs.PlayerHands = []PlayerHand{PlayerHand([]int{2, 2, 2}), PlayerHand([]int{1, 1}), PlayerHand([]int{4, 4})}
 	gs.PrevMove = PlayerMove{MoveType: BET, Value: Bet{6, 2}}
 	gs.CurrentPlayerIndex = 1
@@ -123,6 +125,7 @@ func Test_DudoIdentifyLosersWinnersDudoTrue(t *testing.T) {
 
 func Test_DudoIdentifyLosersWinnersWrappers(t *testing.T) {
 	var gs GameState
+	gs.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gs.PlayerHands = []PlayerHand{PlayerHand([]int{2, 2, 2}), PlayerHand([]int{1, 1}), PlayerHand([]int{4, 4})}
 	gs.PrevMove = PlayerMove{MoveType: BET, Value: Bet{6, 2}}
 	gs.CurrentPlayerIndex = 0

--- a/message_handlers/game/game_processplayermove_test.go
+++ b/message_handlers/game/game_processplayermove_test.go
@@ -10,7 +10,7 @@ import (
 
 func Test_updatePlayerIndexFinalBetDudoFalseNoDeath(t *testing.T) {
 	gameState := GameState{PlayerHands: []PlayerHand{PlayerHand{1, 2}, PlayerHand{2, 3}, PlayerHand{3}},
-		PrevMove: PlayerMove{MoveType: BET, Value: Bet{4, 2}}}
+		RoundMoveHistory: []PlayerMove{{MoveType: BET, Value: Bet{4, 2}}}}
 	// player_index 2 called Dudo
 	// the bet was false
 	// therefore player_1 loses a dice
@@ -23,7 +23,7 @@ func Test_updatePlayerIndexFinalBetDudoFalseNoDeath(t *testing.T) {
 }
 func Test_updatePlayerIndexFinalBetDudoFalseDeath(t *testing.T) {
 	gameState := GameState{PlayerHands: []PlayerHand{PlayerHand{1, 2}, PlayerHand{2, 3}, PlayerHand{3}},
-		PrevMove: PlayerMove{MoveType: BET, Value: Bet{4, 2}}}
+		RoundMoveHistory: []PlayerMove{{MoveType: BET, Value: Bet{4, 2}}}}
 	// player_index 0 called Dudo
 	// the bet was false
 	// therefore player_index 2 loses a dice
@@ -38,7 +38,7 @@ func Test_updatePlayerIndexFinalBetDudoFalseDeath(t *testing.T) {
 
 func Test_updatePlayerIndexFinalBetDudoTrueNoDeath(t *testing.T) {
 	gameState := GameState{PlayerHands: []PlayerHand{PlayerHand{1, 2}, PlayerHand{2, 3}, PlayerHand{3}},
-		PrevMove: PlayerMove{MoveType: BET, Value: Bet{3, 2}}}
+		RoundMoveHistory: []PlayerMove{{MoveType: BET, Value: Bet{3, 2}}}}
 	// player_index 2 called Dudo
 	// the bet was true
 	// therefore player_2 loses a dice
@@ -51,7 +51,7 @@ func Test_updatePlayerIndexFinalBetDudoTrueNoDeath(t *testing.T) {
 }
 func Test_updatePlayerIndexFinalBetDudoTrueDeath(t *testing.T) {
 	gameState := GameState{PlayerHands: []PlayerHand{PlayerHand{3}, PlayerHand{2, 3}, PlayerHand{1, 2}},
-		PrevMove: PlayerMove{MoveType: BET, Value: Bet{3, 2}}}
+		RoundMoveHistory: []PlayerMove{{MoveType: BET, Value: Bet{3, 2}}}}
 	// player_index 0 called Dudo
 	// the bet was true
 	// therefore player_index 0 loses a dice
@@ -66,7 +66,7 @@ func Test_updatePlayerIndexFinalBetDudoTrueDeath(t *testing.T) {
 
 func Test_updatePlayerIndexFinalBetCalzaTrueNoDeath(t *testing.T) { // should be explored for testing processPlayerCalza
 	gameState := GameState{PlayerHands: []PlayerHand{PlayerHand{1, 2}, PlayerHand{2, 3}, PlayerHand{3, 4, 4, 4, 4}},
-		PrevMove: PlayerMove{MoveType: BET, Value: Bet{3, 2}}}
+		RoundMoveHistory: []PlayerMove{{MoveType: BET, Value: Bet{3, 2}}}}
 	// player_index 2 called Calza
 	// the bet was true
 	// therefore player_2 tries to gain a dice, but can't
@@ -83,7 +83,7 @@ func Test_processPlayerDudoFalse(t *testing.T) {
 	gs.PlayerHands = []PlayerHand{PlayerHand([]int{2, 2, 2}), PlayerHand([]int{1, 1}), PlayerHand([]int{4, 4})}
 	gs.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	util.ChanSink(gs.PlayerChannels)
-	gs.PrevMove = PlayerMove{MoveType: BET, Value: Bet{5, 2}}
+	gs.RoundMoveHistory = []PlayerMove{{MoveType: BET, Value: Bet{5, 2}}}
 	gs.CurrentPlayerIndex = 1
 	gs.PalacifoablePlayers = []bool{true, true, true}
 	// playerMove := PlayerMove{MoveType: DUDO}     // Dudo False, so P1 loses a dice
@@ -103,7 +103,7 @@ func Test_DudoIdentifyLosersWinnersDudoFalse(t *testing.T) {
 	var gs GameState
 	gs.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gs.PlayerHands = []PlayerHand{PlayerHand([]int{2, 2, 2}), PlayerHand([]int{1, 1}), PlayerHand([]int{4, 4})}
-	gs.PrevMove = PlayerMove{MoveType: BET, Value: Bet{5, 2}}
+	gs.RoundMoveHistory = []PlayerMove{{MoveType: BET, Value: Bet{5, 2}}}
 	gs.CurrentPlayerIndex = 1
 	// DUDO FALSE
 	loser, winner, _ := gs.DudoIdentifyLosersWinners()
@@ -115,7 +115,7 @@ func Test_DudoIdentifyLosersWinnersDudoTrue(t *testing.T) {
 	var gs GameState
 	gs.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gs.PlayerHands = []PlayerHand{PlayerHand([]int{2, 2, 2}), PlayerHand([]int{1, 1}), PlayerHand([]int{4, 4})}
-	gs.PrevMove = PlayerMove{MoveType: BET, Value: Bet{6, 2}}
+	gs.RoundMoveHistory = []PlayerMove{{MoveType: BET, Value: Bet{6, 2}}}
 	gs.CurrentPlayerIndex = 1
 	// DUDO TRUE
 	loser, winner, _ := gs.DudoIdentifyLosersWinners()
@@ -127,7 +127,7 @@ func Test_DudoIdentifyLosersWinnersWrappers(t *testing.T) {
 	var gs GameState
 	gs.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gs.PlayerHands = []PlayerHand{PlayerHand([]int{2, 2, 2}), PlayerHand([]int{1, 1}), PlayerHand([]int{4, 4})}
-	gs.PrevMove = PlayerMove{MoveType: BET, Value: Bet{6, 2}}
+	gs.RoundMoveHistory = []PlayerMove{{MoveType: BET, Value: Bet{6, 2}}}
 	gs.CurrentPlayerIndex = 0
 	// DUDO TRUE
 	loser, winner, _ := gs.DudoIdentifyLosersWinners()
@@ -144,7 +144,7 @@ func Test_CalzaShouldntBePossibleOnFirstMoveOfRoundNoPrevMove(t *testing.T) {
 }
 
 func Test_CalzaShouldntBePossibleOnFirstMoveOfRoundDudoPrevMove(t *testing.T) {
-	gs := GameState{PlayerHands: []PlayerHand{{1, 1, 1}, {3, 3, 3}, {4, 4, 4}}, PrevMove: PlayerMove{MoveType: DUDO}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 3))}
+	gs := GameState{PlayerHands: []PlayerHand{{1, 1, 1}, {3, 3, 3}, {4, 4, 4}}, RoundMoveHistory: []PlayerMove{{MoveType: DUDO}}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 3))}
 	util.ChanSink(gs.PlayerChannels)
 
 	res := gs.processPlayerCalza()
@@ -152,7 +152,7 @@ func Test_CalzaShouldntBePossibleOnFirstMoveOfRoundDudoPrevMove(t *testing.T) {
 }
 
 func Test_CalzaShouldntBePossibleOnFirstMoveOfRoundCalzaPrevMove(t *testing.T) {
-	gs := GameState{PlayerHands: []PlayerHand{{1, 1, 1}, {3, 3, 3}, {4, 4, 4}}, PrevMove: PlayerMove{MoveType: CALZA}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 3))}
+	gs := GameState{PlayerHands: []PlayerHand{{1, 1, 1}, {3, 3, 3}, {4, 4, 4}}, RoundMoveHistory: []PlayerMove{{MoveType: CALZA}}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 3))}
 	util.ChanSink(gs.PlayerChannels)
 
 	res := gs.processPlayerCalza()
@@ -168,7 +168,7 @@ func Test_DudoShouldntBePossibleOnFirstMoveOfRoundNoPrevMove(t *testing.T) {
 }
 
 func Test_DudoShouldntBePossibleOnFirstMoveOfRoundDudoPrevMove(t *testing.T) {
-	gs := GameState{PlayerHands: []PlayerHand{{1, 1, 1}, {3, 3, 3}, {4, 4, 4}}, PrevMove: PlayerMove{MoveType: DUDO}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 3))}
+	gs := GameState{PlayerHands: []PlayerHand{{1, 1, 1}, {3, 3, 3}, {4, 4, 4}}, RoundMoveHistory: []PlayerMove{{MoveType: DUDO}}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 3))}
 	util.ChanSink(gs.PlayerChannels)
 
 	res := gs.processPlayerDudo()
@@ -176,7 +176,7 @@ func Test_DudoShouldntBePossibleOnFirstMoveOfRoundDudoPrevMove(t *testing.T) {
 }
 
 func Test_DudoShouldntBePossibleOnFirstMoveOfRoundCalzaPrevMove(t *testing.T) {
-	gs := GameState{PlayerHands: []PlayerHand{{1, 1, 1}, {3, 3, 3}, {4, 4, 4}}, PrevMove: PlayerMove{MoveType: CALZA}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 3))}
+	gs := GameState{PlayerHands: []PlayerHand{{1, 1, 1}, {3, 3, 3}, {4, 4, 4}}, RoundMoveHistory: []PlayerMove{{MoveType: CALZA}}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 3))}
 	util.ChanSink(gs.PlayerChannels)
 
 	res := gs.processPlayerDudo()
@@ -192,7 +192,7 @@ func Test_rejectOnesOnTheFirstMove(t *testing.T) {
 }
 func Test_rejectOnesOnTheFirstMoveAfterADudo(t *testing.T) {
 	gs := GameState{PlayerHands: []PlayerHand{{1, 1, 1}, {3, 3, 3}, {4, 4, 4}}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 3))}
-	gs.PrevMove = PlayerMove{MoveType: DUDO}
+	gs.RoundMoveHistory = []PlayerMove{{MoveType: DUDO}}
 	util.ChanSink(gs.PlayerChannels)
 	bet := Bet{FaceVal: 1, NumDice: 1}
 	res := gs.processPlayerBet(PlayerMove{MoveType: BET, Value: bet})
@@ -200,7 +200,7 @@ func Test_rejectOnesOnTheFirstMoveAfterADudo(t *testing.T) {
 }
 func Test_rejectOnesOnTheFirstMoveAfterACalza(t *testing.T) {
 	gs := GameState{PlayerHands: []PlayerHand{{1, 1, 1}, {3, 3, 3}, {4, 4, 4}}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 3))}
-	gs.PrevMove = PlayerMove{MoveType: CALZA}
+	gs.RoundMoveHistory = []PlayerMove{{MoveType: CALZA}}
 	util.ChanSink(gs.PlayerChannels)
 	bet := Bet{FaceVal: 1, NumDice: 1}
 	res := gs.processPlayerBet(PlayerMove{MoveType: BET, Value: bet})
@@ -209,7 +209,7 @@ func Test_rejectOnesOnTheFirstMoveAfterACalza(t *testing.T) {
 
 func Test_checkPalacifoBettingRuleOnePlayerFirstTime(t *testing.T) {
 	gs := GameState{PlayerHands: []PlayerHand{{1}, {3, 3, 3}, {4, 4, 4}}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 3)), PalacifoablePlayers: []bool{false, true, true}}
-	gs.PrevMove = PlayerMove{MoveType: DUDO}
+	gs.RoundMoveHistory = []PlayerMove{{MoveType: DUDO}}
 	util.ChanSink(gs.PlayerChannels)
 	gs.IsPalacifoRound = true
 	bet := Bet{1, 1}
@@ -221,7 +221,7 @@ func Test_checkPalacifoBettingRuleOnePlayerFirstTime(t *testing.T) {
 func Test_checkPalacifoBettingRulePalacifoFollowingMove(t *testing.T) {
 	gs := GameState{PlayerHands: []PlayerHand{{1}, {3, 3, 3}, {4, 4, 4}}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 3)), PalacifoablePlayers: []bool{false, true, true}}
 	gs.IsPalacifoRound = true
-	gs.PrevMove = PlayerMove{MoveType: DUDO}
+	gs.RoundMoveHistory = []PlayerMove{{MoveType: DUDO}}
 	gs.CurrentPlayerIndex = 0
 	util.ChanSink(gs.PlayerChannels)
 	bet := Bet{1, 1}
@@ -239,7 +239,7 @@ func Test_checkPalacifoBettingRulePalacifoFollowingMovePlayerWithOneDice(t *test
 	gs := GameState{PlayerHands: []PlayerHand{{1}, {3}, {4, 4, 4}}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 3)), PalacifoablePlayers: []bool{false, false, true}}
 	gs.IsPalacifoRound = true
 	bet := Bet{1, 1}
-	gs.PrevMove = PlayerMove{MoveType: BET, Value: bet}
+	gs.RoundMoveHistory = []PlayerMove{{MoveType: BET, Value: bet}}
 	gs.CurrentPlayerIndex = 1
 	util.ChanSink(gs.PlayerChannels)
 
@@ -254,7 +254,7 @@ func Test_checkPalacifoBettingRulePalacifoFollowingMovePlayerWithOneDice(t *test
 }
 func Test_checkPalacifoOnesBiddableFirstTurn(t *testing.T) {
 	gs := GameState{PlayerHands: []PlayerHand{{1}, {3, 3, 3}, {4, 4, 4}}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 3)), PalacifoablePlayers: []bool{false, true, true}}
-	gs.PrevMove = PlayerMove{MoveType: DUDO}
+	gs.RoundMoveHistory = []PlayerMove{{MoveType: DUDO}}
 	// t.Log(gs.PrevMove.Value.FaceVal)
 	gs.IsPalacifoRound = true
 	gs.CurrentPlayerIndex = 0
@@ -269,7 +269,7 @@ func Test_onPalacifoOnesNotWildcard(t *testing.T) {
 	gs := GameState{PlayerHands: []PlayerHand{{1}, {3, 3, 3}, {4, 4, 4}}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 3)), PalacifoablePlayers: []bool{false, true, true}}
 	gs.IsPalacifoRound = true
 	bet_dependant_on_one := Bet{FaceVal: 3, NumDice: 4}
-	gs.PrevMove = PlayerMove{MoveType: BET, Value: bet_dependant_on_one}
+	gs.RoundMoveHistory = []PlayerMove{{MoveType: BET, Value: bet_dependant_on_one}}
 	gs.CurrentPlayerIndex = 1
 	util.ChanSink(gs.PlayerChannels)
 	res := gs.ProcessPlayerMove(PlayerMove{MoveType: DUDO})
@@ -282,7 +282,7 @@ func Test_onPalacifoCalzaNotAllowed(t *testing.T) {
 	util.ChanSink(gs.PlayerChannels)
 	gs.IsPalacifoRound = true
 	bet_dependant_on_one := Bet{FaceVal: 3, NumDice: 3}
-	gs.PrevMove = PlayerMove{MoveType: BET, Value: bet_dependant_on_one}
+	gs.RoundMoveHistory = []PlayerMove{{MoveType: BET, Value: bet_dependant_on_one}}
 	gs.CurrentPlayerIndex = 1
 	res := gs.ProcessPlayerMove(PlayerMove{MoveType: CALZA})
 	util.Assert(t, res == false)
@@ -291,7 +291,7 @@ func Test_onPalacifoCalzaNotAllowed(t *testing.T) {
 
 func Test_updatePlayerIndexFinalBetDudoTrueNoDeathNotPalacifo(t *testing.T) { // not sure what this tests
 	gameState := GameState{PlayerHands: []PlayerHand{PlayerHand{1, 2, 4}, PlayerHand{2, 3, 5}, PlayerHand{3, 5, 6}},
-		PrevMove: PlayerMove{MoveType: BET, Value: Bet{3, 2}}}
+		RoundMoveHistory: []PlayerMove{{MoveType: BET, Value: Bet{3, 2}}}}
 	gameState.processPlayerBet(PlayerMove{MoveType: BET, Value: Bet{2, 2}})
 
 	util.Assert(t, gameState.IsPalacifoRound == false)
@@ -314,7 +314,7 @@ func Test_gameRoundStartUpdatesPalacifoablePlayers(t *testing.T) {
 }
 
 func Test_PalacifoBettingOrder(t *testing.T) {
-	gs := GameState{PlayerHands: []PlayerHand{{1}, {2}, {6}}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 3)), PalacifoablePlayers: []bool{false, false, false}, PrevMove: PlayerMove{MoveType: DUDO}}
+	gs := GameState{PlayerHands: []PlayerHand{{1}, {2}, {6}}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 3)), PalacifoablePlayers: []bool{false, false, false}, RoundMoveHistory: []PlayerMove{{MoveType: DUDO}}}
 	util.ChanSink(gs.PlayerChannels)
 	gs.IsPalacifoRound = true
 	// On a Palaifo round, if a player has 1 dice, they can change faceval following
@@ -365,7 +365,7 @@ func Test_startNewGameResetsPalaficoablePlayers(t *testing.T) {
 }
 
 func Test_byDefaultRoundAfterPalacifoIsNotAlsoPalacifo(t *testing.T) {
-	gs := GameState{PlayerHands: []PlayerHand{{1}, {3, 3, 3}, {4, 4, 4}}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 3)), PalacifoablePlayers: []bool{false, false, true}, PrevMove: PlayerMove{MoveType: BET, Value: Bet{FaceVal: 3, NumDice: 3}}}
+	gs := GameState{PlayerHands: []PlayerHand{{1}, {3, 3, 3}, {4, 4, 4}}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 3)), PalacifoablePlayers: []bool{false, false, true}, RoundMoveHistory: []PlayerMove{{MoveType: BET, Value: Bet{FaceVal: 3, NumDice: 3}}}}
 	gs.CurrentPlayerIndex = 2
 	util.ChanSink(gs.PlayerChannels)
 	gs.IsPalacifoRound = true
@@ -376,7 +376,7 @@ func Test_byDefaultRoundAfterPalacifoIsNotAlsoPalacifo(t *testing.T) {
 	util.Assert(t, slices.Equal(gs.PalacifoablePlayers, []bool{false, false, true}))
 }
 func Test_byDefaultRoundAfterPalacifoIsNotAlsoPalacifoUnlessFollowingPlayerGoesToTheirPalacifoRound(t *testing.T) {
-	gs := GameState{PlayerHands: []PlayerHand{{1}, {3, 3}, {4, 4, 4}}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 3)), PalacifoablePlayers: []bool{false, true, true}, PrevMove: PlayerMove{MoveType: BET, Value: Bet{FaceVal: 3, NumDice: 3}}}
+	gs := GameState{PlayerHands: []PlayerHand{{1}, {3, 3}, {4, 4, 4}}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 3)), PalacifoablePlayers: []bool{false, true, true}, RoundMoveHistory: []PlayerMove{{MoveType: BET, Value: Bet{FaceVal: 3, NumDice: 3}}}}
 	gs.CurrentPlayerIndex = 2
 	util.ChanSink(gs.PlayerChannels)
 	gs.IsPalacifoRound = true
@@ -389,7 +389,7 @@ func Test_byDefaultRoundAfterPalacifoIsNotAlsoPalacifoUnlessFollowingPlayerGoesT
 }
 
 func Test_PalacifoRoundDudoNotCountWildcards(t *testing.T) {
-	gs := GameState{PlayerHands: []PlayerHand{{1}, {2}}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 2)), PalacifoablePlayers: []bool{false, false}, PrevMove: PlayerMove{MoveType: BET, Value: Bet{FaceVal: 2, NumDice: 2}}}
+	gs := GameState{PlayerHands: []PlayerHand{{1}, {2}}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 2)), PalacifoablePlayers: []bool{false, false}, RoundMoveHistory: []PlayerMove{{MoveType: BET, Value: Bet{FaceVal: 2, NumDice: 2}}}}
 	gs.CurrentPlayerIndex = 0
 	util.ChanSink(gs.PlayerChannels)
 	gs.IsPalacifoRound = true
@@ -400,7 +400,7 @@ func Test_PalacifoRoundDudoNotCountWildcards(t *testing.T) {
 }
 
 func Test_NormalRoundDudoDoCountWildcards(t *testing.T) {
-	gs := GameState{PlayerHands: []PlayerHand{{1}, {2}}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 2)), PalacifoablePlayers: []bool{false, false}, PrevMove: PlayerMove{MoveType: BET, Value: Bet{FaceVal: 2, NumDice: 2}}}
+	gs := GameState{PlayerHands: []PlayerHand{{1}, {2}}, PlayerChannels: util.InitialiseChans(make([]chan []byte, 2)), PalacifoablePlayers: []bool{false, false}, RoundMoveHistory: []PlayerMove{{MoveType: BET, Value: Bet{FaceVal: 2, NumDice: 2}}}}
 	gs.CurrentPlayerIndex = 0
 	util.ChanSink(gs.PlayerChannels)
 	gs.IsPalacifoRound = false
@@ -408,4 +408,14 @@ func Test_NormalRoundDudoDoCountWildcards(t *testing.T) {
 	gs.processPlayerDudo()
 	t.Log(gs.PlayerHands)
 	util.Assert(t, len(gs.PlayerHands[1]) == 1)
+}
+
+func Test_validBetGetsAddedToRoundMoveHistory(t *testing.T) {
+	gameState := GameState{PlayerHands: []PlayerHand{{3, 3}, {5, 5}}}
+	gameState.InitialiseSlicesWithDefaults()
+
+	moveToBeMade := PlayerMove{MoveType: BET, Value: Bet{NumDice: 3, FaceVal: 4}, PlayerIndex: 0}
+	gameState.ProcessPlayerMove(moveToBeMade)
+	t.Log(gameState.RoundMoveHistory)
+	util.Assert(t, slices.Equal(gameState.RoundMoveHistory, []PlayerMove{moveToBeMade}))
 }

--- a/message_handlers/game/game_util.go
+++ b/message_handlers/game/game_util.go
@@ -37,7 +37,7 @@ func (gameState *GameState) randomiseCurrentHands() {
 	}
 }
 
-func (gameState *GameState) findNextAlivePlayerInclusive() error {
+func (gameState *GameState) FindNextAlivePlayerInclusive() error {
 	// startingIndex := gameState.CurrentPlayerIndex
 	alivePlayerIndices := gameState.alivePlayerIndices()
 	if len(alivePlayerIndices) < 1 {
@@ -48,7 +48,7 @@ func (gameState *GameState) findNextAlivePlayerInclusive() error {
 	if found {
 		return nil
 	}
-	fmt.Println(indexInAlivePlayerIndices, alivePlayerIndices)
+	// fmt.Println(indexInAlivePlayerIndices, alivePlayerIndices)
 	gameState.CurrentPlayerIndex = alivePlayerIndices[(indexInAlivePlayerIndices)%len(alivePlayerIndices)]
 	return nil
 	// playerDead := len(gameState.PlayerHands[startingIndex]) == 0 && slices.Index(alivePlayerIndices, startingIndex) != -1
@@ -71,7 +71,7 @@ func (gameState *GameState) RemovePlayer(playerIndex int) error {
 	}
 	gameState.PlayerHands[playerIndex] = PlayerHand{}
 	if gameState.CurrentPlayerIndex == playerIndex {
-		err := gameState.findNextAlivePlayerInclusive()
+		err := gameState.FindNextAlivePlayerInclusive()
 		if err != nil {
 			return err
 		}
@@ -89,6 +89,9 @@ func (gameState *GameState) RemovePlayer(playerIndex int) error {
 func (gameState *GameState) CleanUpInactivePlayers() {
 	for i := len(gameState.PlayerChannels) - 1; i >= 0; i-- {
 		if gameState.PlayerChannels[i] == nil {
+			if i < gameState.CurrentPlayerIndex {
+				gameState.CurrentPlayerIndex--
+			}
 			gameState.PlayerHands = slices.Delete(gameState.PlayerHands, i, i+1)
 			gameState.PlayerChannels = slices.Delete(gameState.PlayerChannels, i, i+1)
 			gameState.PalacifoablePlayers = slices.Delete(gameState.PalacifoablePlayers, i, i+1)

--- a/message_handlers/game/game_util.go
+++ b/message_handlers/game/game_util.go
@@ -38,19 +38,30 @@ func (gameState *GameState) randomiseCurrentHands() {
 }
 
 func (gameState *GameState) findNextAlivePlayerInclusive() error {
-	startingIndex := gameState.CurrentPlayerIndex
-
-	playerDead := len(gameState.PlayerHands[gameState.CurrentPlayerIndex]) == 0 && gameState.PlayerChannels[startingIndex] != nil
-	for playerDead {
-		gameState.CurrentPlayerIndex += 1
-		gameState.CurrentPlayerIndex %= len(gameState.PlayerHands)
-		if gameState.CurrentPlayerIndex == startingIndex {
-			err := errors.New("passed a game that has already been won")
-			return err
-		}
-		playerDead = len(gameState.PlayerHands[gameState.CurrentPlayerIndex]) == 0 && gameState.PlayerChannels[gameState.CurrentPlayerIndex] != nil
+	// startingIndex := gameState.CurrentPlayerIndex
+	alivePlayerIndices := gameState.alivePlayerIndices()
+	if len(alivePlayerIndices) < 1 {
+		err := errors.New("passed a game that has already been won")
+		return err
 	}
+	indexInAlivePlayerIndices, found := slices.BinarySearch(alivePlayerIndices, gameState.CurrentPlayerIndex)
+	if found {
+		return nil
+	}
+	fmt.Println(indexInAlivePlayerIndices, alivePlayerIndices)
+	gameState.CurrentPlayerIndex = alivePlayerIndices[(indexInAlivePlayerIndices)%len(alivePlayerIndices)]
 	return nil
+	// playerDead := len(gameState.PlayerHands[startingIndex]) == 0 && slices.Index(alivePlayerIndices, startingIndex) != -1
+	// for playerDead {
+	// 	gameState.CurrentPlayerIndex += 1
+	// 	gameState.CurrentPlayerIndex %= len(gameState.PlayerHands)
+	// 	if gameState.CurrentPlayerIndex == startingIndex {
+	// 		err := errors.New("passed a game that has already been won")
+	// 		return err
+	// 	}
+	// 	playerDead = len(gameState.PlayerHands[gameState.CurrentPlayerIndex]) == 0 && slices.Index(alivePlayerIndices, gameState.CurrentPlayerIndex) != -1
+	// }
+	// return nil
 }
 
 func (gameState *GameState) RemovePlayer(playerIndex int) error {

--- a/message_handlers/game/game_util_test.go
+++ b/message_handlers/game/game_util_test.go
@@ -62,6 +62,7 @@ func Test_nextPlayerAliveDeadPlayer(t *testing.T) {
 	var gameState GameState
 	gameState.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{}), PlayerHand([]int{5}), PlayerHand([]int{4, 5, 6})}
+	gameState.InitialiseSlicesWithDefaults()
 	gameState.CurrentPlayerIndex = 0
 	err := gameState.findNextAlivePlayerInclusive()
 	if err != nil {
@@ -143,4 +144,60 @@ func Test_cleanUpInactivePlayers(t *testing.T) {
 	gameState.CleanUpInactivePlayers()
 	t.Log(len(gameState.PlayerChannels))
 	util.Assert(t, len(gameState.PlayerChannels) == 4)
+}
+
+func Test_skipInactivePlayerInBettingRound(t *testing.T) { // Jim
+	var gs GameState
+	gs.PlayerHands = []PlayerHand{PlayerHand{2, 2}, PlayerHand{3, 3}, PlayerHand{5, 5}}
+	gs.InitialiseSlicesWithDefaults()
+	gs.PlayerChannels[1] = nil
+	// gs.RoundMoveHistory = []PlayerMove{{MoveType: BET, Value: Bet{FaceVal: 4, NumDice: 1}, PlayerIndex: 0}}
+	betToBeMade := PlayerMove{MoveType: BET, Value: Bet{FaceVal: 4, NumDice: 1}, PlayerIndex: 0}
+	gs.CurrentPlayerIndex = 0
+
+	gs.ProcessPlayerMove(betToBeMade)
+
+	t.Log(gs.CurrentPlayerIndex, gs.RoundMoveHistory)
+	util.Assert(t, gs.CurrentPlayerIndex == 2)
+
+	util.Assert(t, slices.Equal(gs.RoundMoveHistory, []PlayerMove{betToBeMade}))
+	// t.FailNow()
+}
+
+func Test_previousInactivePlayerSkippedOnDudo(t *testing.T) { // Alex
+	var gs GameState
+	gs.PlayerHands = []PlayerHand{PlayerHand{2, 2}, PlayerHand{3, 3}, PlayerHand{5, 5}}
+	gs.InitialiseSlicesWithDefaults()
+	gs.PlayerChannels[1] = nil
+	gs.RoundMoveHistory = []PlayerMove{{MoveType: BET, Value: Bet{FaceVal: 4, NumDice: 1}, PlayerIndex: 0}}
+	gs.CurrentPlayerIndex = 2
+
+	gs.ProcessPlayerMove(PlayerMove{MoveType: DUDO, PlayerIndex: 2})
+
+	util.Assert(t, gs.CurrentPlayerIndex == 0)
+}
+
+func Test_previousInactivePlayerSkippedOnCalza(t *testing.T) { // Jim
+	var gs GameState
+	gs.PlayerHands = []PlayerHand{PlayerHand{2, 2}, PlayerHand{3, 3}, PlayerHand{5, 5}}
+	gs.InitialiseSlicesWithDefaults()
+	gs.PlayerChannels[1] = nil
+	gs.RoundMoveHistory = []PlayerMove{{MoveType: BET, Value: Bet{FaceVal: 4, NumDice: 1}, PlayerIndex: 0}}
+	gs.CurrentPlayerIndex = 2
+
+	gs.ProcessPlayerMove(PlayerMove{MoveType: CALZA, PlayerIndex: 2})
+
+	util.Assert(t, gs.CurrentPlayerIndex == 2)
+}
+
+func Test_StartNewRoundDeletingInactivePlayers(t *testing.T) { // Jim
+	var gs GameState
+	gs.PlayerHands = []PlayerHand{PlayerHand{2, 2}, PlayerHand{3, 3}, PlayerHand{5, 5}}
+	gs.InitialiseSlicesWithDefaults()
+	gs.PlayerChannels[1] = nil
+
+	gs.startNewRound()
+
+	util.Assert(t, len(gs.PlayerChannels) == 2)
+	util.Assert(t, len(gs.PlayerHands) == 2)
 }

--- a/message_handlers/game/game_util_test.go
+++ b/message_handlers/game/game_util_test.go
@@ -51,7 +51,7 @@ func Test_nextPlayerAliveAlivePlayers(t *testing.T) {
 	gameState.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{1, 2, 3}), PlayerHand([]int{5}), PlayerHand([]int{4, 5, 6})}
 	gameState.CurrentPlayerIndex = 0
-	err := gameState.findNextAlivePlayerInclusive()
+	err := gameState.FindNextAlivePlayerInclusive()
 	if err != nil {
 		t.Fail()
 	}
@@ -64,7 +64,7 @@ func Test_nextPlayerAliveDeadPlayer(t *testing.T) {
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{}), PlayerHand([]int{5}), PlayerHand([]int{4, 5, 6})}
 	gameState.InitialiseSlicesWithDefaults()
 	gameState.CurrentPlayerIndex = 0
-	err := gameState.findNextAlivePlayerInclusive()
+	err := gameState.FindNextAlivePlayerInclusive()
 	if err != nil {
 		t.Fail()
 	}
@@ -200,4 +200,34 @@ func Test_StartNewRoundDeletingInactivePlayers(t *testing.T) { // Jim
 
 	util.Assert(t, len(gs.PlayerChannels) == 2)
 	util.Assert(t, len(gs.PlayerHands) == 2)
+}
+
+func Test_CleanInactivePlayersCurrentPlayerIndexChangedByInactivePlayers(t *testing.T) {
+	var gs GameState
+	gs.PlayerHands = []PlayerHand{{2}, {3}, {5}}
+	gs.InitialiseSlicesWithDefaults()
+
+	gs.CurrentPlayerIndex = 2
+	gs.PlayerChannels[1] = nil
+
+	gs.CleanUpInactivePlayers()
+
+	t.Log(gs.CurrentPlayerIndex)
+	util.Assert(t, len(gs.PlayerChannels) == 2)
+	util.Assert(t, gs.CurrentPlayerIndex == 1)
+}
+
+func Test_startNewRoundCurrentPlayerIndexChangedByInactivePlayers(t *testing.T) {
+	var gs GameState
+	gs.PlayerHands = []PlayerHand{{2}, {3}, {5}}
+	gs.InitialiseSlicesWithDefaults()
+
+	gs.CurrentPlayerIndex = 2
+	gs.PlayerChannels[1] = nil
+
+	gs.startNewRound()
+
+	t.Log(gs.CurrentPlayerIndex)
+	util.Assert(t, len(gs.PlayerChannels) == 2)
+	util.Assert(t, gs.CurrentPlayerIndex == 1)
 }

--- a/message_handlers/game/game_util_test.go
+++ b/message_handlers/game/game_util_test.go
@@ -9,6 +9,7 @@ import (
 
 func Test_RemoveDice(t *testing.T) {
 	var gameState GameState
+	gameState.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{1, 2, 3}), PlayerHand([]int{5, 4, 1}), PlayerHand([]int{4, 5, 6})}
 
 	PLAYER_INDEX := 1
@@ -28,6 +29,7 @@ func Test_RemoveDice(t *testing.T) {
 
 func Test_RemoveDiceKilling(t *testing.T) {
 	var gameState GameState
+	gameState.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{1, 2, 3}), PlayerHand([]int{5}), PlayerHand([]int{4, 5, 6})}
 	PLAYER_INDEX := 1
 	death, err := gameState.removeDice(PLAYER_INDEX)
@@ -46,6 +48,7 @@ func Test_RemoveDiceKilling(t *testing.T) {
 
 func Test_nextPlayerAliveAlivePlayers(t *testing.T) {
 	var gameState GameState
+	gameState.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{1, 2, 3}), PlayerHand([]int{5}), PlayerHand([]int{4, 5, 6})}
 	gameState.CurrentPlayerIndex = 0
 	err := gameState.findNextAlivePlayerInclusive()
@@ -57,6 +60,7 @@ func Test_nextPlayerAliveAlivePlayers(t *testing.T) {
 }
 func Test_nextPlayerAliveDeadPlayer(t *testing.T) {
 	var gameState GameState
+	gameState.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{}), PlayerHand([]int{5}), PlayerHand([]int{4, 5, 6})}
 	gameState.CurrentPlayerIndex = 0
 	err := gameState.findNextAlivePlayerInclusive()
@@ -127,4 +131,16 @@ func Test_removePlayerCausingVictory(t *testing.T) {
 	expectedMessage := messages.CreateEncodedMessage(messages.Message{TypeDescriptor: "GameResult", Contents: GameResult{1, "win"}})
 	util.Assert(t, gameState.GameInProgress == false)
 	util.Assert(t, slices.Equal(winningResult, expectedMessage))
+}
+
+func Test_cleanUpInactivePlayers(t *testing.T) {
+	var gameState GameState
+	gameState.PlayerChannels = util.InitialiseChans(make([]chan []byte, 5))
+	gameState.InitialiseSlicesWithDefaults()
+	t.Log(gameState.PlayerChannels)
+	gameState.PlayerChannels[3] = nil
+
+	gameState.CleanUpInactivePlayers()
+	t.Log(len(gameState.PlayerChannels))
+	util.Assert(t, len(gameState.PlayerChannels) == 4)
 }

--- a/message_handlers/game/playerbet_test.go
+++ b/message_handlers/game/playerbet_test.go
@@ -20,7 +20,7 @@ func Test_updatePlayerIndexRunsNonEmptyPlayerHands(t *testing.T) {
 	var gamestate GameState
 
 	gamestate.PlayerHands = []PlayerHand{PlayerHand([]int{1, 3, 4, 5}), PlayerHand([]int{2, 4, 4}), PlayerHand([]int{4, 5, 4})}
-
+	gamestate.InitialiseSlicesWithDefaults()
 	err := gamestate.updatePlayerIndex(BET) //Expecting success to be false
 	if !(err == nil) {
 		t.Fail()
@@ -31,8 +31,9 @@ func Test_updatePlayerIndexRunsNonEmptyPlayerHands(t *testing.T) {
 func Test_checkPlayerIndexIncrementsClean(t *testing.T) {
 	var gameState GameState
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{1, 3, 4, 5}), PlayerHand([]int{2, 4, 4}), PlayerHand([]int{4, 5, 4})}
+	gameState.InitialiseSlicesWithDefaults()
 	gameState.CurrentPlayerIndex = 0
-	gameState.PrevMove = PlayerMove{MoveType: "Bet", Value: Bet{NumDice: 2, FaceVal: 2}}
+	gameState.RoundMoveHistory = []PlayerMove{{MoveType: "Bet", Value: Bet{NumDice: 2, FaceVal: 2}}}
 
 	gameState.updatePlayerIndex(BET)
 
@@ -46,8 +47,9 @@ func Test_checkPlayerIndexIncrementsClean(t *testing.T) {
 func Test_checkPlayerIndexIncrementsWrapArround(t *testing.T) {
 	var gameState GameState
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{1, 3, 4, 5}), PlayerHand([]int{2, 4, 4}), PlayerHand([]int{4, 5, 4})}
+	gameState.InitialiseSlicesWithDefaults()
 	gameState.CurrentPlayerIndex = 2
-	gameState.PrevMove = PlayerMove{MoveType: "Bet", Value: Bet{NumDice: 2, FaceVal: 2}}
+	gameState.RoundMoveHistory = []PlayerMove{{MoveType: "Bet", Value: Bet{NumDice: 2, FaceVal: 2}}}
 
 	gameState.updatePlayerIndex(BET)
 
@@ -63,7 +65,7 @@ func Test_checkPlayerIndexIncrementsDeadPlayer(t *testing.T) {
 	gameState.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{1, 3, 4, 5}), PlayerHand([]int{}), PlayerHand([]int{4, 5, 4})}
 	gameState.CurrentPlayerIndex = 0
-	gameState.PrevMove = PlayerMove{MoveType: "Bet", Value: Bet{NumDice: 2, FaceVal: 2}}
+	gameState.RoundMoveHistory = []PlayerMove{{MoveType: "Bet", Value: Bet{NumDice: 2, FaceVal: 2}}}
 
 	gameState.updatePlayerIndex(BET)
 
@@ -80,7 +82,7 @@ func Test_checkPlayerIndexAllPlayersDead(t *testing.T) {
 	gameState.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{}), PlayerHand([]int{}), PlayerHand([]int{})}
 	gameState.CurrentPlayerIndex = 0
-	gameState.PrevMove = PlayerMove{MoveType: "Bet", Value: Bet{NumDice: 2, FaceVal: 2}}
+	gameState.RoundMoveHistory = []PlayerMove{{MoveType: "Bet", Value: Bet{NumDice: 2, FaceVal: 2}}}
 
 	err := gameState.updatePlayerIndex(BET) //We expect to fail
 	if !(err.Error() == "all players are dead") {
@@ -97,7 +99,7 @@ func Test_checkPlayerIndexSinglePlayerAlive(t *testing.T) {
 	gameState.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{5, 5}), PlayerHand([]int{}), PlayerHand([]int{})}
 	gameState.CurrentPlayerIndex = 0
-	gameState.PrevMove = PlayerMove{MoveType: "Bet", Value: Bet{NumDice: 2, FaceVal: 2}}
+	gameState.RoundMoveHistory = []PlayerMove{{MoveType: "Bet", Value: Bet{NumDice: 2, FaceVal: 2}}}
 
 	err := gameState.updatePlayerIndex(BET) //We expect to fail
 	if err != nil {
@@ -123,6 +125,7 @@ func Test_updatePlayerIndexDudoTrue(t *testing.T) {
 func Test_updatePlayerIndexDudoFalse(t *testing.T) {
 	var gs GameState
 	gs.PlayerHands = []PlayerHand{PlayerHand([]int{2, 2, 3}), PlayerHand([]int{1, 2}), PlayerHand([]int{5})}
+	gs.InitialiseSlicesWithDefaults()
 	gs.CurrentPlayerIndex = 1
 	losing_player_index := 1
 	err := gs.updatePlayerIndex(DUDO, losing_player_index)
@@ -137,6 +140,7 @@ func Test_updatePlayerIndexCalza(t *testing.T) {
 	var gs GameState
 	gs.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gs.PlayerHands = []PlayerHand{PlayerHand([]int{2, 2, 3}), PlayerHand([]int{1, 2}), PlayerHand([]int{5})}
+	gs.InitialiseSlicesWithDefaults()
 	gs.CurrentPlayerIndex = 1
 	losing_player_index := 1
 	err := gs.updatePlayerIndex(CALZA, losing_player_index)

--- a/message_handlers/game/playerbet_test.go
+++ b/message_handlers/game/playerbet_test.go
@@ -60,6 +60,7 @@ func Test_checkPlayerIndexIncrementsWrapArround(t *testing.T) {
 
 func Test_checkPlayerIndexIncrementsDeadPlayer(t *testing.T) {
 	var gameState GameState
+	gameState.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{1, 3, 4, 5}), PlayerHand([]int{}), PlayerHand([]int{4, 5, 4})}
 	gameState.CurrentPlayerIndex = 0
 	gameState.PrevMove = PlayerMove{MoveType: "Bet", Value: Bet{NumDice: 2, FaceVal: 2}}
@@ -76,6 +77,7 @@ func Test_checkPlayerIndexIncrementsDeadPlayer(t *testing.T) {
 func Test_checkPlayerIndexAllPlayersDead(t *testing.T) {
 
 	var gameState GameState
+	gameState.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{}), PlayerHand([]int{}), PlayerHand([]int{})}
 	gameState.CurrentPlayerIndex = 0
 	gameState.PrevMove = PlayerMove{MoveType: "Bet", Value: Bet{NumDice: 2, FaceVal: 2}}
@@ -92,6 +94,7 @@ func Test_checkPlayerIndexAllPlayersDead(t *testing.T) {
 func Test_checkPlayerIndexSinglePlayerAlive(t *testing.T) {
 
 	var gameState GameState
+	gameState.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{5, 5}), PlayerHand([]int{}), PlayerHand([]int{})}
 	gameState.CurrentPlayerIndex = 0
 	gameState.PrevMove = PlayerMove{MoveType: "Bet", Value: Bet{NumDice: 2, FaceVal: 2}}
@@ -105,6 +108,7 @@ func Test_checkPlayerIndexSinglePlayerAlive(t *testing.T) {
 
 func Test_updatePlayerIndexDudoTrue(t *testing.T) {
 	var gs GameState
+	gs.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gs.PlayerHands = []PlayerHand{PlayerHand([]int{2, 2, 3}), PlayerHand([]int{1}), PlayerHand([]int{5})}
 	gs.CurrentPlayerIndex = 1
 	losing_player_index := 0
@@ -131,6 +135,7 @@ func Test_updatePlayerIndexDudoFalse(t *testing.T) {
 
 func Test_updatePlayerIndexCalza(t *testing.T) {
 	var gs GameState
+	gs.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	gs.PlayerHands = []PlayerHand{PlayerHand([]int{2, 2, 3}), PlayerHand([]int{1, 2}), PlayerHand([]int{5})}
 	gs.CurrentPlayerIndex = 1
 	losing_player_index := 1

--- a/message_handlers/game/playercalza_test.go
+++ b/message_handlers/game/playercalza_test.go
@@ -15,7 +15,7 @@ func xTest_processPlayerMoveCalzaTrue(t *testing.T) {
 			<-gs.PlayerChannels[1]
 		}
 	}()
-	gs.PrevMove = PlayerMove{MoveType: "Bet", Value: Bet{5, 2}}
+	gs.RoundMoveHistory = []PlayerMove{{MoveType: "Bet", Value: Bet{5, 2}}}
 	gs.CurrentPlayerIndex = 1
 	playerMove := PlayerMove{MoveType: "Calza"} // True
 	validity := gs.ProcessPlayerMove(playerMove)
@@ -38,7 +38,7 @@ func xTest_processPlayerMoveCalzaFalse(t *testing.T) {
 			<-gs.PlayerChannels[1]
 		}
 	}()
-	gs.PrevMove = PlayerMove{MoveType: "Bet", Value: Bet{5, 2}}
+	gs.RoundMoveHistory = []PlayerMove{{MoveType: "Bet", Value: Bet{5, 2}}}
 	gs.CurrentPlayerIndex = 1
 	playerMove := PlayerMove{MoveType: "Calza"} // False only 4 2's
 	validity := gs.ProcessPlayerMove(playerMove)

--- a/message_handlers/game/playerdudo_test.go
+++ b/message_handlers/game/playerdudo_test.go
@@ -26,7 +26,7 @@ func Test_generateNewHands(t *testing.T) {
 
 func Test_isBetTrueSimpleCase(t *testing.T) {
 	var gameState GameState
-	gameState.PrevMove = PlayerMove{MoveType: "Bet", Value: Bet{5, 2}}
+	gameState.RoundMoveHistory = []PlayerMove{{MoveType: "Bet", Value: Bet{5, 2}}}
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{2, 2, 2}), PlayerHand([]int{2, 2})} //Exactly true
 	if !gameState.isBetTrue() {
 		t.Fail()
@@ -52,7 +52,7 @@ func Test_isBetTrueSimpleCase(t *testing.T) {
 
 func Test_isBetTrueOnesCase(t *testing.T) {
 	var gameState GameState
-	gameState.PrevMove = PlayerMove{MoveType: "Bet", Value: Bet{5, 2}}
+	gameState.RoundMoveHistory = []PlayerMove{{MoveType: "Bet", Value: Bet{5, 2}}}
 	gameState.PlayerHands = []PlayerHand{PlayerHand([]int{2, 2, 2}), PlayerHand([]int{1, 1})} //Exactly true
 	if !gameState.isBetTrue() {
 		t.Fail()
@@ -82,7 +82,7 @@ func Test_processPlayerMoveDudoFalse(t *testing.T) {
 	gs.PlayerChannels = util.InitialiseChans(make([]chan []byte, 3))
 	util.ChanSink(gs.PlayerChannels)
 	gs.PalacifoablePlayers = []bool{true, true, true}
-	gs.PrevMove = PlayerMove{MoveType: BET, Value: Bet{5, 2}}
+	gs.RoundMoveHistory = []PlayerMove{{MoveType: BET, Value: Bet{5, 2}}}
 	gs.CurrentPlayerIndex = 1
 	playerMove := PlayerMove{MoveType: DUDO}     // Dudo False, so P1 loses a dice
 	validity := gs.ProcessPlayerMove(playerMove) // not a big fan of 'validity', would rather 'move could be made' or similar
@@ -106,7 +106,7 @@ func Test_processPlayerMoveDudoTrue(t *testing.T) {
 			<-gs.PlayerChannels[1]
 		}
 	}()
-	gs.PrevMove = PlayerMove{MoveType: "Bet", Value: Bet{5, 2}}
+	gs.RoundMoveHistory = []PlayerMove{{MoveType: "Bet", Value: Bet{5, 2}}}
 	gs.CurrentPlayerIndex = 1
 	playerMove := PlayerMove{MoveType: "Dudo"} // True only 4 2's
 	validity := gs.ProcessPlayerMove(playerMove)
@@ -114,8 +114,8 @@ func Test_processPlayerMoveDudoTrue(t *testing.T) {
 		t.Error(validity)
 	}
 	t.Log(gs.CurrentPlayerIndex)
-	util.Assert(t, gs.CurrentPlayerIndex == 0) // ✓
-
+	util.Assert(t, gs.CurrentPlayerIndex == 0)    // ✓
+	util.Assert(t, len(gs.RoundMoveHistory) == 0) // ✓
 }
 
 func Test_processPlayerMoveDudoFalseKilling(t *testing.T) {
@@ -139,7 +139,7 @@ func Test_processPlayerMoveDudoFalseKilling(t *testing.T) {
 			<-gs.PlayerChannels[2]
 		}
 	}()
-	gs.PrevMove = PlayerMove{MoveType: "Bet", Value: Bet{2, 2}}
+	gs.RoundMoveHistory = []PlayerMove{{MoveType: "Bet", Value: Bet{2, 2}}}
 	gs.PalacifoablePlayers = []bool{true, true, true}
 	gs.CurrentPlayerIndex = 1
 	playerMove := PlayerMove{MoveType: "Dudo"} // False 3 2's, so P1 loses and dies

--- a/message_handlers/gameHandler.go
+++ b/message_handlers/gameHandler.go
@@ -140,36 +140,13 @@ func (gameHandler *GameHandler) processLeaveGameHeadingBackToUnPH(thisChan chan 
 
 	gameHandler.removePlayerChannelFromGameMaintainingPlayability(thisChan)
 	gameHandler.GlobalUnassignedPlayerHandler.AddChannel(thisChan)
-	// if !gameHandler.gameState.GameInProgress {
-	// 	playerLocationMessage := messages.Message{TypeDescriptor: "PlayerLocation", Contents: "/"}
-	// 	message_handler_interface.Send(thisChan, playerLocationMessage)
-	// 	gameHandler.MoveChannel(thisChan, gameHandler.GlobalUnassignedPlayerHandler)
-	// 	return
-	// }
-	// // The game is in progress, remove the relevant player
-	// thisChanIndex := slices.Index[[]chan []byte](gameHandler.gameState.PlayerChannels, thisChan)
-	// gameHandler.GlobalUnassignedPlayerHandler.AddChannel(thisChan)
-	// gameHandler.gameState.PlayerChannels[thisChanIndex] = nil
-	// // currentPlayerQuit := thisChanIndex == gameHandler.gameState.CurrentPlayerIndex
-	// // gameHandler.gameState.RemovePlayer(thisChanIndex)
-	// gameHandler.gameState.SetPlayerInactive(thisChanIndex) // mark the player as inactive (so they will pass)
-
-	// // Then once we have moved the channel, we should inform the other players that they have left
-	// // and potentially update the CurrentPlayerIndex clientside.
-	// msg := messages.Message{TypeDescriptor: "PlayerLeft", Contents: thisChanIndex} // this tells the front end that this play is now inactive
-
-	// gameHandler.Broadcast(msg)
-
 }
 
 func (gameHandler GameHandler) Broadcast(message messages.Message, optional_use_wait_group ...bool) {
 	message_handler_interface.BroadcastLogic(gameHandler.gameState.PlayerChannels, message, optional_use_wait_group...)
 }
 func (gameHandler *GameHandler) RemoveChannel(thisChan chan []byte) {
-	// gameHandler.removePlayerChannelFromGameMaintainingPlayability(thisChan)
-	gameHandler.processLeaveGameHeadingBackToUnPH(thisChan)
+	gameHandler.removePlayerChannelFromGameMaintainingPlayability(thisChan)
 	delete(*gameHandler.channelLocations, thisChan) // This is also done at call site in main.
-	// gameHandler.gameState.PlayerChannels[thisChanIndex] = nil
-
 	// this channel will be cleared up higher up where RemoveChannel was called. We have removed all internal references to this channel.
 }

--- a/message_handlers/gameHandler.go
+++ b/message_handlers/gameHandler.go
@@ -118,8 +118,16 @@ func (gameHandler *GameHandler) ProcessUserMessage(userMessage messages.Message,
 
 func (gameHandler *GameHandler) removePlayerChannelFromGameMaintainingPlayability(thisChan chan []byte) {
 	thisChanIndex := slices.Index[[]chan []byte](gameHandler.gameState.PlayerChannels, thisChan)
-	gameHandler.gameState.PlayerChannels[thisChanIndex] = nil
 	fmt.Printf("Player %d is being removed from the game while maintaining playability \n", thisChanIndex)
+	if thisChanIndex == -1 {
+		fmt.Println("Couldn't find the player that was attempting to leave. V bad")
+		return
+	}
+	gameHandler.gameState.PlayerChannels[thisChanIndex] = nil
+	gameHandler.gameState.FindNextAlivePlayerInclusive()
+	gameHandler.gameState.AllowableChannelLock = gameHandler.gameState.CurrentPlayerIndex
+	gameHandler.gameState.BroadcastNextPlayer()
+
 	msg := messages.Message{TypeDescriptor: "PlayerLeft", Contents: thisChanIndex} // this tells the front end that this play is now inactive
 	gameHandler.Broadcast(msg)
 	if !gameHandler.gameState.GameInProgress {

--- a/message_handlers/gameHandler.go
+++ b/message_handlers/gameHandler.go
@@ -72,6 +72,7 @@ func (gameHandler *GameHandler) ProcessUserMessage(userMessage messages.Message,
 			fmt.Println(err.Error())
 			return
 		}
+		playerMove.PlayerIndex = thisChanIndex
 		fmt.Println("Calling gamestate.processPlayerMove")
 		couldProcessMove := gameHandler.gameState.ProcessPlayerMove(playerMove)
 		if !couldProcessMove {

--- a/message_handlers/game_handler_test.go
+++ b/message_handlers/game_handler_test.go
@@ -196,3 +196,26 @@ func xTest_singlePlayerLeavesGameInProgressWithOtherPlayer(t *testing.T) {
 	util.Assert(t, len(unPH.UnassignedPlayers) == 1)
 	util.Assert(t, unPH.UnassignedPlayers[0] == thisChan)
 }
+
+func Test_currentPlayerDisconnectsGameInProgress(t *testing.T) {
+	var gh GameHandler
+	gh.gameState.PlayerHands = []game.PlayerHand{{2}, {3}, {5}}
+	gh.gameState.InitialiseSlicesWithDefaults()
+	gh.gameState.GameInProgress = true
+	gh.gameState.CurrentPlayerIndex = 0
+	unPH := UnassignedPlayerHandler{}
+	channelLocations := message_handler_interface.ChannelLocations{}
+	unPH.channelLocations = &channelLocations
+	gh.channelLocations = &channelLocations
+	gh.GlobalUnassignedPlayerHandler = &unPH
+	for _, thisChan := range gh.gameState.PlayerChannels {
+		channelLocations[thisChan] = &gh
+	}
+	msg := messages.Message{TypeDescriptor: "LeaveGame"}
+	gh.ProcessUserMessage(msg, gh.gameState.PlayerChannels[0])
+
+	t.Log(len(gh.gameState.PlayerChannels))
+	util.Assert(t, len(gh.gameState.PlayerChannels) == 3)
+	util.Assert(t, gh.gameState.PlayerChannels[0] == nil)
+	util.Assert(t, gh.gameState.CurrentPlayerIndex == 1)
+}

--- a/message_handlers/game_handler_test.go
+++ b/message_handlers/game_handler_test.go
@@ -5,13 +5,12 @@ import (
 	"HigherLevelPerudoServer/message_handlers/message_handler_interface"
 	"HigherLevelPerudoServer/messages"
 	"HigherLevelPerudoServer/util"
-	"slices"
 	"testing"
 )
 
 func Test_singlePlayerLeavesGameNotInProgress(t *testing.T) {
 	gh := GameHandler{}
-	gh.gameState.GameInProgress = false
+
 	channelLocations := message_handler_interface.ChannelLocations{}
 	unPH := UnassignedPlayerHandler{}
 	unPH.SetChannelLocations(&channelLocations)
@@ -20,10 +19,13 @@ func Test_singlePlayerLeavesGameNotInProgress(t *testing.T) {
 	thisChan := make(chan []byte)
 	util.ChanSink([]chan []byte{thisChan})
 	gh.gameState.PlayerChannels = []chan []byte{thisChan}
+	gh.gameState.StartNewGame()
+	gh.gameState.GameInProgress = false
 	channelLocations[thisChan] = &gh
 	// Finished setup
 	msg := messages.Message{TypeDescriptor: "LeaveGame"}
 	gh.ProcessUserMessage(msg, thisChan)
+	t.Log(len(gh.gameState.PlayerChannels), len(unPH.UnassignedPlayers))
 	util.Assert(t, len(gh.gameState.PlayerChannels) == 0)
 	util.Assert(t, len(unPH.UnassignedPlayers) == 1)
 	util.Assert(t, unPH.UnassignedPlayers[0] == thisChan)
@@ -41,6 +43,8 @@ func Test_singlePlayerLeavesGameWithOtherPlayerInNotInProgress(t *testing.T) {
 	otherChan := make(chan []byte)
 	util.ChanSink([]chan []byte{thisChan, otherChan})
 	gh.gameState.PlayerChannels = []chan []byte{thisChan, otherChan}
+	gh.gameState.StartNewGame()
+	gh.gameState.GameInProgress = false
 	channelLocations[thisChan] = &gh
 	channelLocations[otherChan] = &gh
 	// Finished setup
@@ -68,6 +72,8 @@ func Test_singlePlayerMovesMultiplePlayersToLobbyGameFinished(t *testing.T) {
 	otherChan := make(chan []byte)
 	util.ChanSink([]chan []byte{thisChan, otherChan})
 	gh.gameState.PlayerChannels = []chan []byte{thisChan, otherChan}
+	gh.gameState.StartNewGame()
+	gh.gameState.GameInProgress = false
 	channelLocations[thisChan] = &gh
 	channelLocations[otherChan] = &gh
 	// Finished setup
@@ -118,28 +124,35 @@ func Test_singlePlayerMovesMultiplePlayersToLobbyGameInProgress(t *testing.T) {
 	// util.Assert(t, lobby.LobbyID == GAMEID)
 }
 
-func Test_singlePlayerLeavesGameInProgress(t *testing.T) {
+func Test_singlePlayerLeavesGameInProgressWithOtherPlayers(t *testing.T) {
 	gh := GameHandler{}
+	playerChan := make(chan []byte)
+	util.ChanSink([]chan []byte{playerChan})
+	gh.gameState.PlayerChannels = []chan []byte{playerChan}
 	gh.gameState.GameInProgress = true
-	gh.gameState.PlayerHands = []game.PlayerHand{game.PlayerHand([]int{2, 2, 2})} //Give it a PlayerHands
+	gh.gameState.PlayerHands = []game.PlayerHand{game.PlayerHand{2}, game.PlayerHand{3}, game.PlayerHand{4}} //Give it a PlayerHands
+	gh.gameState.InitialiseSlicesWithDefaults()
+
 	channelLocations := message_handler_interface.ChannelLocations{}
 	unPH := UnassignedPlayerHandler{}
 	unPH.SetChannelLocations(&channelLocations)
 	gh.SetChannelLocations(&channelLocations)
 	gh.GlobalUnassignedPlayerHandler = &unPH
-	thisChan := make(chan []byte)
-	util.ChanSink([]chan []byte{thisChan})
-	gh.gameState.PlayerChannels = []chan []byte{thisChan}
-	channelLocations[thisChan] = &gh
+	gh.gameState.StartNewGame()
+	gh.gameState.GameInProgress = true
+	for _, thisChan := range gh.gameState.PlayerChannels {
+		channelLocations[thisChan] = &gh
+	}
 	// Finished setup
 	msg := messages.Message{TypeDescriptor: "LeaveGame"}
-	gh.ProcessUserMessage(msg, thisChan)
-	util.Assert(t, len(gh.gameState.PlayerChannels) == 0)
-	util.Assert(t, len(gh.gameState.PlayerChannels) == 0)
+	gh.ProcessUserMessage(msg, playerChan)
+	t.Log(len(gh.gameState.PlayerChannels))
+	util.Assert(t, len(gh.gameState.PlayerChannels) == 3)
+	util.Assert(t, gh.gameState.PlayerChannels[0] == nil)
 	util.Assert(t, len(unPH.UnassignedPlayers) == 1)
-	util.Assert(t, unPH.UnassignedPlayers[0] == thisChan)
+	util.Assert(t, unPH.UnassignedPlayers[0] == playerChan)
 }
-func Test_singlePlayerLeavesGameInProgressWithOtherPlayer(t *testing.T) {
+func xTest_singlePlayerLeavesGameInProgressWithOtherPlayer(t *testing.T) {
 	gh := GameHandler{}
 	gh.gameState.GameInProgress = true
 	gh.gameState.PlayerHands = []game.PlayerHand{game.PlayerHand([]int{2, 2, 2}), game.PlayerHand([]int{3, 3, 3})} //Give it a PlayerHands
@@ -150,26 +163,31 @@ func Test_singlePlayerLeavesGameInProgressWithOtherPlayer(t *testing.T) {
 	gh.GlobalUnassignedPlayerHandler = &unPH
 	thisChan := make(chan []byte)
 	otherChan := make(chan []byte)
-	util.ChanSink([]chan []byte{thisChan}) //Don't sink otherChan
+	// util.ChanSink([]chan []byte{thisChan}) //Don't sink otherChan
+	util.ChanSink([]chan []byte{thisChan, otherChan}) //Do sink otherChan
 	gh.gameState.PlayerChannels = []chan []byte{thisChan, otherChan}
+	gh.gameState.StartNewGame()
+	gh.gameState.GameInProgress = true
 	channelLocations[thisChan] = &gh
 	channelLocations[otherChan] = &gh
 	// Finished setup
 	msg := messages.Message{TypeDescriptor: "LeaveGame"}
-	go gh.ProcessUserMessage(msg, thisChan)
+	// go gh.ProcessUserMessage(msg, thisChan)
+	gh.ProcessUserMessage(msg, thisChan)
 
 	// The following messages are sent in a random order which isn't ideal:
-	otherChansMessage1 := <-otherChan
-	otherChansMessage2 := <-otherChan
-	expectedMessage1 := messages.CreateEncodedMessage(messages.Message{TypeDescriptor: "GameResult", Contents: game.GameResult{1, "win"}})
-	expectedMessage2 := messages.CreateEncodedMessage(messages.Message{TypeDescriptor: "PlayerLeft", Contents: 0})
-	if slices.Equal(otherChansMessage1, expectedMessage1) {
-		util.Assert(t, slices.Equal(otherChansMessage2, expectedMessage2))
-	} else if slices.Equal(otherChansMessage1, expectedMessage2) {
-		util.Assert(t, slices.Equal(otherChansMessage2, expectedMessage1))
-	} else {
-		t.Error("failed at the randomness")
-	}
+	// otherChansMessage1 := <-otherChan
+	// _ = otherChansMessage1
+	// otherChansMessage2 := <-otherChan
+	// expectedMessage1 := messages.CreateEncodedMessage(messages.Message{TypeDescriptor: "GameResult", Contents: game.GameResult{1, "win"}})
+	// expectedMessage2 := messages.CreateEncodedMessage(messages.Message{TypeDescriptor: "PlayerLeft", Contents: 0})
+	// if slices.Equal(otherChansMessage1, expectedMessage1) {
+	// 	util.Assert(t, slices.Equal(otherChansMessage2, expectedMessage2))
+	// } else if slices.Equal(otherChansMessage1, expectedMessage2) {
+	// 	util.Assert(t, slices.Equal(otherChansMessage2, expectedMessage1))
+	// } else {
+	// 	t.Error("failed at the randomness")
+	// }
 	t.Log(gh.gameState.PlayerChannels)
 	util.Assert(t, len(gh.gameState.PlayerChannels) == 1)
 	util.Assert(t, gh.gameState.PlayerChannels[0] == otherChan)

--- a/message_handlers/game_handler_test.go
+++ b/message_handlers/game_handler_test.go
@@ -152,7 +152,7 @@ func Test_singlePlayerLeavesGameInProgressWithOtherPlayers(t *testing.T) {
 	util.Assert(t, len(unPH.UnassignedPlayers) == 1)
 	util.Assert(t, unPH.UnassignedPlayers[0] == playerChan)
 }
-func xTest_singlePlayerLeavesGameInProgressWithOtherPlayer(t *testing.T) {
+func Test_singlePlayerLeavesGameInProgressWithOtherPlayer(t *testing.T) {
 	gh := GameHandler{}
 	gh.gameState.GameInProgress = true
 	gh.gameState.PlayerHands = []game.PlayerHand{game.PlayerHand([]int{2, 2, 2}), game.PlayerHand([]int{3, 3, 3})} //Give it a PlayerHands
@@ -175,23 +175,10 @@ func xTest_singlePlayerLeavesGameInProgressWithOtherPlayer(t *testing.T) {
 	// go gh.ProcessUserMessage(msg, thisChan)
 	gh.ProcessUserMessage(msg, thisChan)
 
-	// The following messages are sent in a random order which isn't ideal:
-	// otherChansMessage1 := <-otherChan
-	// _ = otherChansMessage1
-	// otherChansMessage2 := <-otherChan
-	// expectedMessage1 := messages.CreateEncodedMessage(messages.Message{TypeDescriptor: "GameResult", Contents: game.GameResult{1, "win"}})
-	// expectedMessage2 := messages.CreateEncodedMessage(messages.Message{TypeDescriptor: "PlayerLeft", Contents: 0})
-	// if slices.Equal(otherChansMessage1, expectedMessage1) {
-	// 	util.Assert(t, slices.Equal(otherChansMessage2, expectedMessage2))
-	// } else if slices.Equal(otherChansMessage1, expectedMessage2) {
-	// 	util.Assert(t, slices.Equal(otherChansMessage2, expectedMessage1))
-	// } else {
-	// 	t.Error("failed at the randomness")
-	// }
 	t.Log(gh.gameState.PlayerChannels)
-	util.Assert(t, len(gh.gameState.PlayerChannels) == 1)
-	util.Assert(t, gh.gameState.PlayerChannels[0] == otherChan)
-	util.Assert(t, len(gh.gameState.PlayerHands) == 1)
+	util.Assert(t, len(gh.gameState.PlayerChannels) == 2)
+	util.Assert(t, gh.gameState.PlayerChannels[0] == nil)
+	util.Assert(t, len(gh.gameState.PlayerHands) == 2)
 
 	util.Assert(t, len(unPH.UnassignedPlayers) == 1)
 	util.Assert(t, unPH.UnassignedPlayers[0] == thisChan)


### PR DESCRIPTION
Refractored PrevMove to be a method. Currently still has the same logic as before. Gives scope to consider inactive players. 